### PR TITLE
Draft: support having only the sheet directory mounted

### DIFF
--- a/multi-checker/script/check.py
+++ b/multi-checker/script/check.py
@@ -64,6 +64,9 @@ def candsFromTitle(origTitle: str) -> list[str]:
 
 _numRe = re.compile(r'\b\d+\b')
 def getSheetFromEnv(testDir):
+    task_id = os.environ.get('TASK_ID_CUSTOM')
+    if task_id is not None and task_id != '':
+        return task_id
     origTitle = os.environ.get('TASK_TITLE').strip()
     cands = candsFromTitle(origTitle)
     m = _numRe.search(origTitle)
@@ -74,17 +77,6 @@ def getSheetFromEnv(testDir):
         if isDir(d):
             return c
     return cands[-1]  # prefer the more generic
-
-
-_DEFAULT_TEST_DIR = '/external/praktomat-tests'
-
-def getDefaultTestDir(cmd):
-    if cmd == 'python':
-        return pjoin(_DEFAULT_TEST_DIR, 'python-prog1')
-    elif cmd == 'java':
-        return pjoin(_DEFAULT_TEST_DIR, 'java-aud')
-    else:
-        return pjoin(_DEFAULT_TEST_DIR, 'haskell-advanced-prog')
 
 def getAssignments(s: str|None) -> list[str] | None:
     assignments = None
@@ -105,8 +97,9 @@ def main():
     cmd = args.cmd
     if not cmd:
         abort('command not given on commandline')
-    testDir = args.test_dir or getDefaultTestDir(cmd)
-    testDir = abspath(testDir)
+    testDir = args.test_dir
+    if testDir is not None:
+        testDir = abspath(testDir)
     submissionDir = args.submission_dir or '.'
     submissionDir = submissionDir.rstrip('/')
     submissionDir = abspath(submissionDir)

--- a/multi-checker/script/common.py
+++ b/multi-checker/script/common.py
@@ -14,7 +14,9 @@ class Options:
     testDir: Optional[str]
     resultFile: Optional[str]
 
-def getSheetDir(testDir, sheet):
+def getSheetDir(testDir: Optional[str], sheet: str):
+    if testDir is None:
+        return '/external'
     return pjoin(testDir, sheet)
 
 def replaceAll(l: list[str], repl: str, s: str) -> str:

--- a/multi-checker/tests/runTests.py
+++ b/multi-checker/tests/runTests.py
@@ -20,6 +20,7 @@ useDocker = True
 
 praktomatTestsDocker = '/praktomat-tests'
 praktomatCheckersDocker = '/praktomat-checkers'
+sheetDirDocker = '/external'
 
 if useDocker:
     praktomatTests = praktomatTestsDocker
@@ -46,7 +47,7 @@ def debug(msg: str):
 
 testCount = 0
 
-def runCmd(cmd: str, onError='raise', capture=False, dir=None, env=None):
+def runCmd(cmd: str, onError='raise', capture=False, external=None, dir=None, env=None):
     if useDocker:
         workDirArg = ""
         if dir is not None:
@@ -55,32 +56,36 @@ def runCmd(cmd: str, onError='raise', capture=False, dir=None, env=None):
             envStr = ' '.join([f'-e {k}="{v}"' for k,v in env.items()])
         else:
             envStr = ''
-        cmd = f'docker run {envStr} --rm --volume {praktomatCheckersLocal}:{praktomatCheckersDocker} '\
+        cmdDocker = f'docker run {envStr} --rm --volume {praktomatCheckersLocal}:{praktomatCheckersDocker} '\
             f'--volume {praktomatTestsLocal}:{praktomatTestsDocker} '\
             f'--volume $HOME/devel/tick-trick-track:/external/tick-trick-track '\
-            f'{workDirArg} {dockerImage} {cmd}'
+            f'{workDirArg} '
+        if external is not None:
+            cmdDocker += f'--volume {external}:{sheetDirDocker} '
+        cmdDocker += f'{dockerImage} {cmd}'
+        cmd = cmdDocker
     debug(cmd)
     return run(cmd, onError=onError, captureStderr=capture, captureStdout=capture,
                stderrToStdout=capture, env=env)
 
-def expectOk(cmd: str, dir=None, env=None):
+def expectOk(cmd: str, external=None, dir=None, env=None):
     global testCount
     testCount = testCount + 1
     print()
     info(f'Running test, cmd: {cmd}')
-    res = runCmd(cmd, onError='ignore', dir=dir, capture=True, env=env)
+    res = runCmd(cmd, onError='ignore', external=external, dir=dir, capture=True, env=env)
     if res.exitcode != 0:
         print(res.stdout)
         fail(f'Command should succeed but failed with exit code {res.exitcode}: {cmd}')
     info('OK')
     return res
 
-def expectFail(cmd: str, ecode=None, dir=None, env=None):
+def expectFail(cmd: str, ecode=None, external=None, dir=None, env=None):
     global testCount
     testCount = testCount + 1
     print()
     info(f'Running test, cmd: {cmd} ...')
-    res = runCmd(cmd, onError='ignore', dir=dir, capture=True, env=env)
+    res = runCmd(cmd, onError='ignore', external=external, dir=dir, capture=True, env=env)
     if res.exitcode == 0:
         print(res.stdout)
         fail(f'Command should fail but succeded with exit code {res.exitcode}: {cmd}')
@@ -111,7 +116,9 @@ if runPythonTests:
     wyppDir = '/wypp/' if useDocker else '$HOME/devel/write-your-python-program/'
 
     pythonTestDir = f'{praktomatTests}/python-prog1/'
+    pythonTestDirLocal = f'{praktomatTestsLocal}/python-prog1'
     python2TestDir = f'{praktomatTests}/python-prog2/'
+    python2TestDirLocal = f'{praktomatTestsLocal}/python-prog2'
     localTestDir = f'{thisDir}/python-wypp'
 
     expectOk(f'python3 {checkScript} --submission-dir {localTestDir} python --wypp {wyppDir} --sheet 01 --assignment 1,4', dir=localTestDir)
@@ -126,66 +133,69 @@ if runPythonTests:
                 ('solution-timeout', 1)]
 
     for d, ecode in pythonTests:
-        cmd = f'python3 {checkScript} --test-dir {localTestDir} --submission-dir {localTestDir}/03/{d}/ python --wypp {wyppDir} --sheet 03'
+        sheetDirLocal = f'{praktomatCheckersLocal}/multi-checker/tests/python-wypp/03'
+        submissionDir = f'{localTestDir}/03/{d}/'
+        cmd = f'python3 {checkScript} --submission-dir {submissionDir} python --wypp {wyppDir} --sheet 03'
         env = {'PRAKTOMAT_CHECKER_TEST_TIMEOUT': '2'}
         if ecode == 0:
-            res = expectOk(cmd, dir=f'{localTestDir}/03/{d}', env=env)
+            res = expectOk(cmd, external=sheetDirLocal, dir=submissionDir, env=env)
         else:
-            res = expectFail(cmd, ecode, env=env)
+            res = expectFail(cmd, ecode, external=sheetDirLocal, dir=submissionDir, env=env)
         if d == 'solution-timeout':
             if 'timeout' not in res.stdout.lower():
                 fail(f'expected timeout in output\n\n---\n{res.stdout}\n---')
 
-    expectOk(f'python3 {checkScript} --test-dir {pythonTestDir} --submission-dir {pythonTestDir}/09/solution/ python --wypp {wyppDir} --sheet 09', dir=f'{pythonTestDir}/09/solution/')
+    expectOk(f'python3 {checkScript} --submission-dir {pythonTestDir}/09/solution/ python --wypp {wyppDir} --sheet 09', external=f'{pythonTestDirLocal}/09', dir=f'{pythonTestDir}/09/solution/')
 
-    expectOk(f'python3 {checkScript} --test-dir {pythonTestDir} --submission-dir {pythonTestDir}/labortest_2/solution/ python --wypp {wyppDir} --sheet labortest_2', dir=f'{pythonTestDir}/labortest_2/solution/')
-    expectFail(f'python3 {checkScript} --test-dir {pythonTestDir} --submission-dir {pythonTestDir}/labortest_2/solution-partial/ python --wypp {wyppDir} --sheet labortest_2', 121, dir=f'{pythonTestDir}/labortest_2/solution-partial/')
-    expectFail(f'python3 {checkScript} --test-dir {pythonTestDir} --submission-dir {pythonTestDir}/labortest_2/solution-nofiles/ python --wypp {wyppDir} --sheet labortest_2', 1, dir=f'{pythonTestDir}/labortest_2/solution-nofiles/')
+    expectOk(f'python3 {checkScript} --submission-dir {pythonTestDir}/labortest_2/solution/ python --wypp {wyppDir} --sheet labortest_2', external=f'{pythonTestDirLocal}/labortest_2', dir=f'{pythonTestDir}/labortest_2/solution/')
+    expectFail(f'python3 {checkScript} --submission-dir {pythonTestDir}/labortest_2/solution-partial/ python --wypp {wyppDir} --sheet labortest_2', 121, external=f'{pythonTestDirLocal}/labortest_2', dir=f'{pythonTestDir}/labortest_2/solution-partial/')
+    expectFail(f'python3 {checkScript} --submission-dir {pythonTestDir}/labortest_2/solution-nofiles/ python --wypp {wyppDir} --sheet labortest_2', 1, external=f'{pythonTestDirLocal}/labortest_2', dir=f'{pythonTestDir}/labortest_2/solution-nofiles/')
 
-    expectFail(f'python3 {checkScript} --test-dir {pythonTestDir} --submission-dir {pythonTestDir}abschlussprojekt/solution-fail python --wypp {wyppDir} --sheet abschlussprojekt', dir=f'{pythonTestDir}abschlussprojekt/solution-fail')
-    expectFail(f'python3 {checkScript} --test-dir {pythonTestDir} --submission-dir {pythonTestDir}abschlussprojekt/solution-simple python --wypp {wyppDir} --sheet abschlussprojekt', 121, dir=f'{pythonTestDir}abschlussprojekt/solution-simple')
-    expectOk(f'python3 {checkScript} --test-dir {pythonTestDir} --submission-dir {pythonTestDir}abschlussprojekt/solution python --wypp {wyppDir} --sheet abschlussprojekt', dir=f'{pythonTestDir}abschlussprojekt/solution')
-    expectOk(f'python3 {checkScript} --test-dir {pythonTestDir} --submission-dir {pythonTestDir}10-dicts-exceptions/solution python --wypp {wyppDir} --sheet 10-dicts-exceptions', dir=f'{pythonTestDir}10/solution')
-    expectOk(f'python3 {checkScript} --test-dir {pythonTestDir} --submission-dir {pythonTestDir}10-dicts-exceptions/solution/subdir python --wypp {wyppDir} --sheet 10-dicts-exceptions', dir=f'{python2TestDir}P04-Listen/solution')
-    expectOk(f'python3 {checkScript} --test-dir {python2TestDir} --submission-dir {python2TestDir}P04-Listen/solution python --wypp {wyppDir} --sheet P04-Listen', dir=f'{python2TestDir}P04-Listen/solution')
+    expectFail(f'python3 {checkScript} --submission-dir {pythonTestDir}abschlussprojekt/solution-fail python --wypp {wyppDir} --sheet abschlussprojekt', external=f'{pythonTestDirLocal}/abschlussprojekt', dir=f'{pythonTestDir}abschlussprojekt/solution-fail')
+    expectFail(f'python3 {checkScript} --submission-dir {pythonTestDir}abschlussprojekt/solution-simple python --wypp {wyppDir} --sheet abschlussprojekt', 121, external=f'{pythonTestDirLocal}/abschlussprojekt', dir=f'{pythonTestDir}abschlussprojekt/solution-simple')
+    expectOk(f'python3 {checkScript} --submission-dir {pythonTestDir}abschlussprojekt/solution python --wypp {wyppDir} --sheet abschlussprojekt', external=f'{pythonTestDirLocal}/abschlussprojekt', dir=f'{pythonTestDir}abschlussprojekt/solution')
+    expectOk(f'python3 {checkScript} --submission-dir {pythonTestDir}10-dicts-exceptions/solution python --wypp {wyppDir} --sheet 10-dicts-exceptions', external=f'{pythonTestDirLocal}/10-dicts-exceptions', dir=f'{pythonTestDir}10/solution')
+    expectOk(f'python3 {checkScript} --submission-dir {pythonTestDir}10-dicts-exceptions/solution/subdir python --wypp {wyppDir} --sheet 10-dicts-exceptions', external=f'{pythonTestDirLocal}/10-dicts-exceptions', dir=f'{python2TestDir}P04-Listen/solution')
+    expectOk(f'python3 {checkScript} --submission-dir {python2TestDir}P04-Listen/solution python --wypp {wyppDir} --sheet P04-Listen', external=f'{python2TestDirLocal}/P04-Listen', dir=f'{python2TestDir}P04-Listen/solution')
 
 if runHaskellTests:
     printHeader('Running Haskell Tests')
 
     haskellTestDir = f'{praktomatTests}/haskell-advanced-prog'
     haskellTestDirLocal = f'{praktomatTestsLocal}/haskell-advanced-prog'
-    expectOk(f'python3 {checkScript} --submission-dir {haskellTestDir}/02/solution/ --test-dir {haskellTestDir} haskell --sheet 02', dir=f'{haskellTestDir}/02/solution/')
-    expectFail(f'python3 {checkScript} --submission-dir {thisDir}/haskell/02-no-file --test-dir {haskellTestDir} haskell --sheet 02', 1, dir=f'{thisDir}/haskell/02-no-file')
+    expectOk(f'python3 {checkScript} --submission-dir {haskellTestDir}/02/solution/ haskell --sheet 02', external=f'{haskellTestDirLocal}/02', dir=f'{haskellTestDir}/02/solution/')
+    expectFail(f'python3 {checkScript} --submission-dir {thisDir}/haskell/02-no-file haskell --sheet 02', 1, external=f'{haskellTestDirLocal}/02', dir=f'{thisDir}/haskell/02-no-file')
 
-    expectFail(f'python3 {checkScript} --submission-dir {thisDir}/haskell/05-divide-by-zero/ --test-dir {haskellTestDir} haskell --sheet 05', 121, dir=f'{thisDir}/haskell/05-divide-by-zero/')
-    expectFail(f'python3 {checkScript} --submission-dir {haskellTestDir}/01/solution/ --test-dir {haskellTestDir} haskell --sheet 01', 121, dir=f'{haskellTestDir}/01/solution/')
-    expectOk(f'python3 {checkScript} --submission-dir {haskellTestDir}/03/solution/ --test-dir {haskellTestDir} haskell --sheet 03', dir=f'{haskellTestDir}/03/solution/')
-    expectOk(f'python3 {checkScript} --submission-dir {haskellTestDir}/04/solution/ --test-dir {haskellTestDir} haskell --sheet 04', dir=f'{haskellTestDir}/04/solution/')
-    expectOk(f'python3 {checkScript} --submission-dir {haskellTestDir}/05/solution/ --test-dir {haskellTestDir} haskell --sheet 05', dir=f'{haskellTestDir}/05/solution/')
-    expectOk(f'python3 {checkScript} --submission-dir {haskellTestDir}/06/solution/ --test-dir {haskellTestDir} haskell --sheet 06', dir=f'{haskellTestDir}/06/solution/')
+    expectFail(f'python3 {checkScript} --submission-dir {thisDir}/haskell/05-divide-by-zero/ haskell --sheet 05', 121, external=f'{haskellTestDirLocal}/05', dir=f'{thisDir}/haskell/05-divide-by-zero/')
+    expectFail(f'python3 {checkScript} --submission-dir {haskellTestDir}/01/solution/ haskell --sheet 01', 121, external=f'{haskellTestDirLocal}/01', dir=f'{haskellTestDir}/01/solution/')
+    expectOk(f'python3 {checkScript} --submission-dir {haskellTestDir}/03/solution/ haskell --sheet 03', external=f'{haskellTestDirLocal}/03', dir=f'{haskellTestDir}/03/solution/')
+    expectOk(f'python3 {checkScript} --submission-dir {haskellTestDir}/04/solution/ haskell --sheet 04', external=f'{haskellTestDirLocal}/04', dir=f'{haskellTestDir}/04/solution/')
+    expectOk(f'python3 {checkScript} --submission-dir {haskellTestDir}/05/solution/ haskell --sheet 05', external=f'{haskellTestDirLocal}/05', dir=f'{haskellTestDir}/05/solution/')
+    expectOk(f'python3 {checkScript} --submission-dir {haskellTestDir}/06/solution/ haskell --sheet 06', external=f'{haskellTestDirLocal}/06', dir=f'{haskellTestDir}/06/solution/')
 
     # Sheet 06 again, but with a nested solution directory
     with tempDir(dir=haskellTestDirLocal) as d:
         cp(f'{haskellTestDirLocal}/06/solution/', pjoin(d, 'solution'))
-        expectOk(f'python3 {checkScript} --submission-dir {pjoin(haskellTestDir, basename(d))} --test-dir {haskellTestDir} haskell --sheet 06', dir=pjoin(haskellTestDir, basename(d)))
+        expectOk(f'python3 {checkScript} --submission-dir {pjoin(haskellTestDir, basename(d))} haskell --sheet 06', external=f'{haskellTestDirLocal}/06', dir=pjoin(haskellTestDir, basename(d)))
 
 if runJavaTests:
     printHeader('Running Java Tests')
 
     javaTestDir = f'{praktomatTests}/java-aud'
+    javaTestDirLocal = f'{praktomatTestsLocal}/java-aud'
     checkstyle = '/opt/praktomat-addons/checkstyle.jar' if useDocker else './checkstyle-10.3.4-all.jar'
     localTestDir = f'{thisDir}/java-aud'
 
-    expectOk(f'python3 {checkScript} --submission-dir {javaTestDir}/01-intro/solution --test-dir {javaTestDir} java --checkstyle {checkstyle} --sheet 01-intro', dir=f'{javaTestDir}/01-intro/solution')
+    expectOk(f'python3 {checkScript} --submission-dir {javaTestDir}/01-intro/solution java --checkstyle {checkstyle} --sheet 01-intro', external=f'{javaTestDirLocal}/01-intro', dir=f'{javaTestDir}/01-intro/solution')
 
     # Solution wrapped in another directory with failing tests
-    expectFail(f'python3 {checkScript} --submission-dir {localTestDir}/passed-with-warnings/wrapper/ --test-dir {javaTestDir} java --checkstyle {checkstyle} --sheet 01-intro', 121, dir=f'{localTestDir}/passed-with-warnings/wrapper/')
+    expectFail(f'python3 {checkScript} --submission-dir {localTestDir}/passed-with-warnings/wrapper/ java --checkstyle {checkstyle} --sheet 01-intro', 121, external=f'{javaTestDirLocal}/01-intro', dir=f'{localTestDir}/passed-with-warnings/wrapper/')
 
     # Submission with BOM and iso encoding and with failing tests
-    expectFail(f'python3 {checkScript} --submission-dir {localTestDir}/passed-with-warnings/AuD_Assignment_01/ --test-dir {javaTestDir} java --checkstyle {checkstyle} --sheet 01-intro', 121, dir=f'{localTestDir}/passed-with-warnings/AuD_Assignment_01/')
+    expectFail(f'python3 {checkScript} --submission-dir {localTestDir}/passed-with-warnings/AuD_Assignment_01/ java --checkstyle {checkstyle} --sheet 01-intro', 121, external=f'{javaTestDirLocal}/01-intro', dir=f'{localTestDir}/passed-with-warnings/AuD_Assignment_01/')
 
     # Submission with checkstyle errors
-    expectFail(f'python3 {checkScript} --submission-dir {localTestDir}/fail/AuD_Assignment_01/ --test-dir {javaTestDir} java --checkstyle {checkstyle} --sheet 01-intro', dir=f'{localTestDir}/fail/AuD_Assignment_01/')
+    expectFail(f'python3 {checkScript} --submission-dir {localTestDir}/fail/AuD_Assignment_01/ java --checkstyle {checkstyle} --sheet 01-intro', external=f'{javaTestDirLocal}/01-intro', dir=f'{localTestDir}/fail/AuD_Assignment_01/')
 
 print()
 info(f'{testCount} tests were run successfully!')


### PR DESCRIPTION
If `TASK_ID_CUSTOM` is specified, we also don't need to supply the sheet name anymore as an argument. It will instead automatically be set to the value of `TASK_ID_CUSTOM`.

If no test directory is given, the sheet directory is assumed to be `/external`. Otherwise, we can still use the old behavior of the checker and supply a test directory. This is required for at least one script in our praktomat-tests repository (for doing local checks).

As of now, the Haskell part of the multi-checker does not work yet as it requires files from the test directory. I did, however, change the Haskell tests already. They are now failing.
@skogsbaer: do you have a solution for this yet?

Depends on hso-praktomat/praktomat#61