### PR TITLE
Add nestedSourceDir integration & update llm-tutor to report missing …

### DIFF
--- a/multi-checker/docker/Dockerfile
+++ b/multi-checker/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN rm -rf /wypp/.git
 # llm-tutor
 RUN mkdir /llm-tutor
 ADD ./git-clone /git-clone
-RUN bash /git-clone https://github.com/alaref-tasnim/LLM-Tutor.git 432f5fd7bc52bda98709f2e2cbc755946a8febd4 /llm-tutor
+RUN bash /git-clone https://github.com/alaref-tasnim/LLM-Tutor.git 9950dd6a5d6232c01d82e8f4d0cc2bf9eb2265b6 /llm-tutor
 RUN rm -rf /llm-tutor/.git
 
 # Install packages for llm-tutor .toml datei

--- a/multi-checker/script/llm_tutor.py
+++ b/multi-checker/script/llm_tutor.py
@@ -79,11 +79,11 @@ def check(opts: LlmTutorOptions):
 
             # student Solution
             debug(f'opts.sourceDir = {opts.sourceDir}')
-            # nestedSourceDir = findSolutionDir(opts.sourceDir)
+            nestedSourceDir = findSolutionDir(opts.sourceDir, lambda x: isDir(pjoin(x, "src")))
 
             if assignemnt.src is None:
                 configError(f'No source file defined for assignment {assignemnt.id}')
-            student_pfad = pjoin(opts.sourceDir, assignemnt.src)
+            student_pfad = pjoin(nestedSourceDir, assignemnt.src)
 
             #api 
             api = parseConfig(pjoin(opts.configApi, 'config.yaml'))


### PR DESCRIPTION
Im Praktomat-Browser werden für jeden Checker ein eigenes `check.sh`-Skript sowie der Submission-Pfad übergeben. Bei zwei Checkern entstehen somit drei Argumente:

1. `check.sh` des ersten Checkers
2. `check_1.sh` des zweiten Checkers
3. Submission-Pfad

findSolutionDir() ruft intern findSolutionDirAux() auf. Diese Funktion verwendet wiederum isNotAWrapperDir().
Das Problem tritt in `isNotAWrapperDir()` (`utils.py`, Zeile 100) auf. Dort wird offenbar angenommen, dass nur zwei Pfade bzw. Argumente übergeben werden. Da tatsächlich drei Argumente vorhanden sind, kommt es zu Fehlern. Aktuell wird dies umgangen, indem beide Checker dieselbe `check.sh`-Datei verwenden, wodurch die bestehende Logik weiterhin funktioniert.
