### PR TITLE
Improve solution directory unwrapping strategy

### DIFF
--- a/multi-checker/script/utils.py
+++ b/multi-checker/script/utils.py
@@ -97,7 +97,7 @@ def findSolutionDirAux(root: str, stopCondition: Optional[Callable], isSolutionR
 
 def isNotAWrapperDir(directory: str, isSolutionRoot: bool) -> bool:
     pathnames = ls(directory, '[!.]*')
-    if len(pathnames) == 2 and isSolutionRoot:
+    if isSolutionRoot:
         # Filter out the script that starts the multi checker
         pathnames = list(filter(lambda x: not (basename(x).startswith('check') and x.endswith('.sh')), pathnames))
     if len(pathnames) > 1:


### PR DESCRIPTION
When more than one ScriptChecker is present, we may end up with more than one check.sh script in the solution root. For this reason, we need to remove the check for exactly two elements in the solution root.